### PR TITLE
Update Working Group to clarify

### DIFF
--- a/community/readme.md
+++ b/community/readme.md
@@ -130,10 +130,12 @@ Working Groups (WGs) are primarily used to facilitate topics of discussion that 
 * have a clear goal measured through specific deliverables
 * will be disbanded after the goal is achieved
 
-If a set of folks in the community want to get together and discuss a topic, they can do so without forming a Working Group. While not exclusively the case, Working Groups output are more often specifications and recommendations for the SIGs than actual code implementation. At time of inception of this organizational structure, the following WGs will be present:
+Working Groups can create specifications, recommendations, or implementations for submission to the relevant SIGs for approval and acceptance. At time of inception of this organizational structure, the following WGs will be present:
 
    * Edge / Mobile
    * Training
+   * Quantization
+   * Data Processing
 
 Working Groups are formed by submitting a proposal via PR to the Steering Committee. The proposal should cover:
 


### PR DESCRIPTION
Previous text allowed for Working Groups to output code implementations. New text makes it explicitly clear.
Also add 2 other working groups that are in progress